### PR TITLE
Fix partial scrolling

### DIFF
--- a/src/slic3r/GUI/Search.cpp
+++ b/src/slic3r/GUI/Search.cpp
@@ -927,11 +927,15 @@ private:
         if (totalHeight <= visibleHeight)
             return;
 
-        int rotation = event.GetWheelRotation();
+        m_sum_wheel_rotation += event.GetWheelRotation() * RowHeight() * 3;
         int delta = event.GetWheelDelta();
         if (delta == 0)
             return;
-        int scrollAmount = (rotation / delta) * RowHeight() * 3;
+        int scrollAmount = m_sum_wheel_rotation / delta;
+        if (scrollAmount == 0)
+            return;
+
+        m_sum_wheel_rotation -= scrollAmount * delta;
 
         int maxScroll = std::max(0, totalHeight - visibleHeight);
         m_scroll_offset = std::max(0, std::min(m_scroll_offset - scrollAmount, maxScroll));
@@ -990,6 +994,7 @@ private:
     int m_selected{-1};
     int m_hovered{-1};
     int m_scroll_offset{0};
+    int m_sum_wheel_rotation{0};
 
     ScrollBar *m_scrollbar{nullptr};
 };

--- a/src/slic3r/GUI/Widgets/ScrollBar.cpp
+++ b/src/slic3r/GUI/Widgets/ScrollBar.cpp
@@ -45,6 +45,7 @@ wxBEGIN_EVENT_TABLE(ScrollBar, wxPanel) EVT_PAINT(ScrollBar::OnPaint) EVT_LEFT_D
     , m_dragging(false)
     , m_dragStartCoord(0)
     , m_dragStartPos(0)
+    , m_sumWheelRotation(0)
 {
     SetBackgroundStyle(wxBG_STYLE_PAINT);
     int width = GetScaledScrollbarWidth();
@@ -192,14 +193,16 @@ void ScrollBar::OnMouseWheel(wxMouseEvent &event)
         return;
     }
 
-    int rotation = event.GetWheelRotation();
-    int delta = event.GetWheelDelta();
-    int lines = rotation / delta;
-
     // Scroll 3 lines per wheel notch
-    int scrollAmount = lines * 3;
-    SetThumbPosition(m_position - scrollAmount);
-    NotifyScroll(wxEVT_SCROLL_THUMBTRACK);
+    m_sumWheelRotation += event.GetWheelRotation() * 3;
+    int delta = event.GetWheelDelta();
+    int scrollAmount = m_sumWheelRotation / delta;
+
+    if (scrollAmount) {
+        m_sumWheelRotation -= scrollAmount * delta;
+        SetThumbPosition(m_position - scrollAmount);
+        NotifyScroll(wxEVT_SCROLL_THUMBTRACK);
+    }
 }
 
 void ScrollBar::OnSize(wxSizeEvent &event)

--- a/src/slic3r/GUI/Widgets/ScrollBar.hpp
+++ b/src/slic3r/GUI/Widgets/ScrollBar.hpp
@@ -71,6 +71,7 @@ private:
     bool m_dragging;
     int m_dragStartCoord;
     int m_dragStartPos;
+    int m_sumWheelRotation;
 
     // DPI scaling - these are now methods instead of constants
     static int GetScaledMinThumbSize();

--- a/src/slic3r/GUI/Widgets/ScrollablePanel.cpp
+++ b/src/slic3r/GUI/Widgets/ScrollablePanel.cpp
@@ -6,6 +6,7 @@
 #include "ScrollBar.hpp"
 #include "UIColors.hpp"
 #include "../GUI_App.hpp"
+#include <cstdio>
 #include <wx/dcclient.h>
 #include <algorithm>
 
@@ -25,7 +26,7 @@ wxBEGIN_EVENT_TABLE(ScrollablePanel, wxPanel) EVT_SIZE(ScrollablePanel::OnSize)
 
         ScrollablePanel::ScrollablePanel(wxWindow *parent, wxWindowID id, const wxPoint &pos, const wxSize &size,
                                          long style)
-    : wxPanel(parent, id, pos, size, style), m_scrollPosition(0), m_contentHeight(0)
+    : wxPanel(parent, id, pos, size, style), m_scrollPosition(0), m_contentHeight(0), m_sumWheelRotation(0)
 {
     // Create content panel directly as child - we'll clip manually via repositioning
     m_content = new wxPanel(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL);
@@ -199,10 +200,14 @@ void ScrollablePanel::OnMouseWheel(wxMouseEvent &event)
         return;
     }
 
-    int rotation = event.GetWheelRotation();
-    int delta = event.GetWheelDelta();
+    m_sumWheelRotation += event.GetWheelRotation() * GetScaledScrollAmount();
 
-    // Scroll per wheel notch (scaled for DPI)
-    int scrollAmount = (rotation / delta) * GetScaledScrollAmount();
-    ScrollToPosition(m_scrollPosition - scrollAmount);
+    int delta = event.GetWheelDelta();
+    int scrollAmount = m_sumWheelRotation / delta;
+
+    if (scrollAmount != 0) {
+        // Scroll per wheel notch (scaled for DPI)
+        m_sumWheelRotation -= scrollAmount * delta;
+        ScrollToPosition(m_scrollPosition - scrollAmount);
+    }
 }

--- a/src/slic3r/GUI/Widgets/ScrollablePanel.hpp
+++ b/src/slic3r/GUI/Widgets/ScrollablePanel.hpp
@@ -73,6 +73,7 @@ private:
     ScrollBar *m_scrollbar; // Custom scrollbar
     int m_scrollPosition;   // Current scroll position in pixels
     int m_contentHeight;    // Cached content height
+    int m_sumWheelRotation; // Accumulating mouse wheel events
 
     wxDECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
At least on linux with xwayland, scroll wheel events are mostly less than GetWheelDelta. This means you had to scroll very quickly for the events to register at all.

This fix implements an accumulator counting the partial rotation events. This is how wxwidgets implements it internally as well (see univ/scrollbar.cpp).

Additionally, by moving the various scroll multipliers to before the delta division, scrolling becomes smoother than with the native wxwidgets scrollbar.

Implemented in scroolbar, scrollablePanel, and the search field.

Only tested on linux with xwayland, but with both mouse and touchpad. It should not have any impact on platforms that already send full steps only.