### PR TITLE
Fix hiding empty groups in sidebar on linux and mac

### DIFF
--- a/src/slic3r/GUI/Sidebar.cpp
+++ b/src/slic3r/GUI/Sidebar.cpp
@@ -991,7 +991,7 @@ void TabbedSettingsPanel::UpdateSidebarVisibility()
                 for (size_t ri = 0; ri < group_sizer->GetItemCount(); ++ri)
                 {
                     wxSizerItem *row_item = group_sizer->GetItem(ri);
-                    if (row_item && row_item->IsShown())
+                    if (row_item && row_item->IsShown() && !row_item->IsSpacer())
                     {
                         any_row_visible = true;
                         break;
@@ -1031,7 +1031,7 @@ void TabbedSettingsPanel::UpdateSidebarVisibility()
                                 for (size_t ri = 0; ri < sub_sizer->GetItemCount(); ++ri)
                                 {
                                     wxSizerItem *ri_item = sub_sizer->GetItem(ri);
-                                    if (ri_item && ri_item->IsShown())
+                                    if (ri_item && ri_item->IsShown() && !ri_item->IsSpacer())
                                     {
                                         any_sub_row = true;
                                         break;


### PR DESCRIPTION
On line 204 a spacer is added to the box sizer on gtk and macos. This means groups were never counted as empty, resulting in this:

<img width="792" height="363" alt="image" src="https://github.com/user-attachments/assets/0b6b4214-4f43-489d-93fa-8c14fd83e08b" />
