### PR TITLE
Increase nozzle diameter UI limit from 2.0 to 10.0mm

### DIFF
--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -1258,7 +1258,7 @@ void SpinCtrlFloatField::BUILD()
     }
 
     const double min_val = m_opt.min > -FLT_MAX ? m_opt.min : 0.1;
-    const double max_val = m_opt.max < FLT_MAX ? m_opt.max : 2.0;
+    const double max_val = m_opt.max < FLT_MAX ? m_opt.max : 10.0;
     const double inc_val = 0.10; // 0.1mm increment to match Print Settings
 
     auto temp = new ::SpinInputDouble(m_parent, wxString::Format("%.1f", default_value), "", wxDefaultPosition, size,

--- a/src/slic3r/GUI/Sidebar.cpp
+++ b/src/slic3r/GUI/Sidebar.cpp
@@ -10203,7 +10203,7 @@ void Sidebar::UpdatePrinterFilamentCombos()
             int spin_width = int(5.5 * em);
             int spin_height = int(2.4 * em); // Proper height for spin control
             auto *spin = new SpinInputDouble(m_printer_content, wxString::Format("%.1f", nozzle_value), "",
-                                             wxDefaultPosition, wxSize(spin_width, spin_height), 0, 0.1, 2.0,
+                                             wxDefaultPosition, wxSize(spin_width, spin_height), 0, 0.1, 10.0,
                                              nozzle_value, 0.10);
             spin->SetDigits(1);
             m_printer_nozzle_spins.push_back(spin);


### PR DESCRIPTION
Raise the maximum in both the printer settings tab spinner (Field.cpp) and the sidebar nozzle spinner (Sidebar.cpp).